### PR TITLE
Adding option in client to specify extra headers

### DIFF
--- a/client.go
+++ b/client.go
@@ -24,6 +24,9 @@ type Client struct {
 	//The Http Client that is used to make requests
 	HttpClient   *http.Client
 	RetryTimeout time.Duration
+
+	//Option to specify extra headers like User-Agent
+	ExtraHeader map[string]string
 }
 
 // valid is the struct to unmarshal validation endpoint responses into.

--- a/integration/client_test.go
+++ b/integration/client_test.go
@@ -52,3 +52,10 @@ func TestBaseUrl(t *testing.T) {
 		assert.Equal(t, "https://another.datadoghq.com", c.GetBaseUrl())
 	})
 }
+
+func TestExtraHeader(t *testing.T) {
+	t.Run("No Extra Header for backward compatibility", func(t *testing.T) {
+		c := datadog.NewClient("foo", "bar")
+		assert.Empty(t, c.ExtraHeader)
+	})
+}

--- a/request.go
+++ b/request.go
@@ -209,5 +209,9 @@ func (client *Client) createRequest(method, api string, reqbody interface{}) (*h
 	if bodyReader != nil {
 		req.Header.Add("Content-Type", "application/json")
 	}
+	for k, v := range client.ExtraHeader {
+		req.Header.Add(k, v)
+	}
+
 	return req, nil
 }


### PR DESCRIPTION
👋 In order to better identify Agents making calls to the API we need to be able to configure the request's context.
Having the extra options at the client level will also allow for other header options to be configured.
(Test will only pass once merged upstream)